### PR TITLE
Collision with automatic generation of indexes in Rails 3.1

### DIFF
--- a/lib/schema_plus/railtie.rb
+++ b/lib/schema_plus/railtie.rb
@@ -14,5 +14,7 @@ module SchemaPlus
       end
     end
 
+    config.app_generators.indexes false
+
   end
 end


### PR DESCRIPTION
As of Rails 3.1 using `belongs_to` or `references` in `rails generate model` results in `add_index` for referenced table. At the same time schema_plus creates such index which results in collision (generated migration fails). The solution is to run the generator with `--no-indexes` option, i.e. `rails g model Foo bar:belongs_to --no-indexes`. My suggestion is to configure Rails to disable these indexes by default.
