### PR TITLE
activerecord >= 3.2 #drop_table gets only single argument

### DIFF
--- a/lib/schema_plus/active_record/connection_adapters/abstract_adapter.rb
+++ b/lib/schema_plus/active_record/connection_adapters/abstract_adapter.rb
@@ -99,7 +99,8 @@ module SchemaPlus
           unless ::ActiveRecord::Base.connection.class.include?(SchemaPlus::ActiveRecord::ConnectionAdapters::Sqlite3Adapter)
             reverse_foreign_keys(name).each { |foreign_key| remove_foreign_key(foreign_key.table_name, foreign_key.name) }
           end
-          drop_table_without_schema_plus(name, options)
+          # drop options because #drop_table doesn't use it actually
+          drop_table_without_schema_plus(name)
         end
 
         # Returns true if the database supports parital indexes (abstract; only


### PR DESCRIPTION
activerecord 2.3, 3.0, 3.1 should work properly with this patch.
