### PR TITLE
Add support for allowing column SQL expression defaults in the database

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -120,6 +120,33 @@ ActiveRecord works with views the same as with ordinary tables.  That is, for th
   class UncommentedPosts < ActiveRecord::Base
   end
 
+=== Column Defaults
+
+SchemaPlus allows expressions to be used as column defaults.  For example:
+
+  t.datetime :seen_at, :default => :now
+
+resolves to
+
+  DEFAULT NOW() # PostgreSQL
+  (DATETIME('now')) # SQLite3
+  invalid # MySQL
+
+Arbitrary SQL expressions can also be specified by passing a hash with an :expr parameter:
+
+  t.datetime :seen_at, :default => { :expr => 'NOW()' }
+
+In MySQL only the TIMESTAMP column accepts SQL column defaults and Rails uses DATETIME,
+so this is not possible at this time.
+
+Standard default values can be specified verbosely:
+
+  t.datetime :seen_at, :default => { :value => "2011-12-11 00:00:00" }
+
+But the standard syntax will still work as usual:
+
+  t.datetime :seen_at, :default => "2011-12-11 00:00:00"
+
 === Schema Dump and Load (schema.rb)
 
 When dumping <tt>schema.rb</tt>, SchemaPlus orders the views and tables in

--- a/lib/schema_plus.rb
+++ b/lib/schema_plus.rb
@@ -20,6 +20,7 @@ module SchemaPlus
     module ConnectionAdapters
       autoload :MysqlAdapter, 'schema_plus/active_record/connection_adapters/mysql_adapter'
       autoload :PostgresqlAdapter, 'schema_plus/active_record/connection_adapters/postgresql_adapter'
+      autoload :PostgreSQLColumn, 'schema_plus/active_record/connection_adapters/postgresql_adapter'
       autoload :Sqlite3Adapter, 'schema_plus/active_record/connection_adapters/sqlite3_adapter'
     end
   end

--- a/lib/schema_plus/active_record/connection_adapters/column.rb
+++ b/lib/schema_plus/active_record/connection_adapters/column.rb
@@ -7,6 +7,7 @@ module SchemaPlus
       #
       module Column
 
+        attr_reader :default_expr
         attr_writer :connection # connection gets set by SchemaPlus::ActiveRecord::Base::columns_with_schema_plus
 
         # Returns the list of IndexDefinition instances for each index that

--- a/lib/schema_plus/active_record/connection_adapters/mysql_adapter.rb
+++ b/lib/schema_plus/active_record/connection_adapters/mysql_adapter.rb
@@ -105,6 +105,12 @@ module SchemaPlus
           sql
         end
 
+        def default_expr_valid?(expr)
+          false # only the TIMESTAMP column accepts SQL column defaults and rails uses DATETIME
+        end
+
+        def sql_for_function(function)
+        end
       end
     end
   end

--- a/lib/schema_plus/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/lib/schema_plus/active_record/connection_adapters/sqlite3_adapter.rb
@@ -1,6 +1,15 @@
 module SchemaPlus
   module ActiveRecord
     module ConnectionAdapters
+      module SQLiteColumn
+        def initialize(name, default, sql_type = nil, null = true)
+          if default =~ /DATETIME/
+            @default_expr = "(#{default})"
+          end
+          super(name, default, sql_type, null)
+        end
+      end
+
       # SchemaPlus includes an Sqlite3 implementation of the AbstractAdapater
       # extensions.  
       module Sqlite3Adapter
@@ -71,6 +80,16 @@ module SchemaPlus
           foreign_keys
         end
 
+        def default_expr_valid?(expr)
+          true # arbitrary sql is okay
+        end
+
+        def sql_for_function(function)
+          case function
+            when :now
+              "(DATETIME('now'))"
+          end
+        end
       end
 
     end

--- a/lib/schema_plus/active_record/schema_dumper.rb
+++ b/lib/schema_plus/active_record/schema_dumper.rb
@@ -98,7 +98,13 @@ module SchemaPlus
       def table_with_schema_plus(table, ignore) #:nodoc:
         stream = StringIO.new
         table_without_schema_plus(table, stream)
-        @table_dumps[table] = stream.string
+        stream_string = stream.string
+        @connection.columns(table).each do |column|
+          if !column.default_expr.nil?
+            stream_string.gsub!("\"#{column.name}\"", "\"#{column.name}\", :default => { :expr => \"#{column.default_expr}\" }")
+          end
+        end
+        @table_dumps[table] = stream_string
       end
 
       def indexes_with_schema_plus(table, stream) #:nodoc:

--- a/spec/column_definition_spec.rb
+++ b/spec/column_definition_spec.rb
@@ -1,0 +1,99 @@
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+
+
+describe "Column definition" do
+  before(:all) do
+    load_core_schema
+  end
+
+  let(:connection) { ActiveRecord::Base.connection }
+
+  before(:each) do
+    @sql = 'time_taken text'
+  end
+
+  context "just default passed" do
+    before(:each) do
+      connection.add_column_options!(@sql, { :default => "2011-12-11 00:00:00" })
+    end
+
+    subject { @sql}
+
+    it "should use the normal default" do
+      should == "time_taken text DEFAULT '2011-12-11 00:00:00'"
+    end
+  end
+
+  context "just default passed in hash" do
+    before(:each) do
+      connection.add_column_options!(@sql, { :default => { :value => "2011-12-11 00:00:00" } })
+    end
+
+    subject { @sql}
+
+    it "should use the normal default" do
+      should == "time_taken text DEFAULT '2011-12-11 00:00:00'"
+    end
+  end
+
+  context "default function passed as now" do
+    before(:each) do
+      connection.add_column_options!(@sql, { :default => :now })
+    end
+
+    subject { @sql }
+
+    if SchemaPlusHelpers.postgresql?
+      it "should use NOW() as the default" do
+        should == "time_taken text DEFAULT NOW()"
+      end
+    end
+
+    if SchemaPlusHelpers.sqlite3?
+      it "should use NOW() as the default" do
+        should == "time_taken text DEFAULT (DATETIME('now'))"
+      end
+    end
+
+    if SchemaPlusHelpers.mysql?
+      it "should use CURRENT_TIMESTAMP as the default" do
+        should == "time_taken text DEFAULT 'now'"
+      end
+    end
+  end
+
+  context "valid expr passed as default" do
+    subject { connection.add_column_options!(@sql, { :default => { :expr => 'NOW()' } }); @sql }
+
+    if SchemaPlusHelpers.postgresql?
+      it "should use NOW() as the default" do
+        should == "time_taken text DEFAULT NOW()"
+      end
+    end
+
+    if SchemaPlusHelpers.sqlite3?
+      it "should use NOW() as the default" do
+        should == "time_taken text DEFAULT NOW()"
+      end
+    end
+
+    if SchemaPlusHelpers.mysql?
+      it "should raise an error" do
+        lambda { subject }.should raise_error
+      end
+    end
+  end
+
+  context "invalid expr passed as default" do
+    if SchemaPlusHelpers.mysql?
+      it "should raise an error" do
+        lambda {connection.add_column_options!(@sql, { :default => { :expr => "ARBITRARY_EXPR" } })}.should raise_error ArgumentError
+      end
+    else
+      it "should just accept the SQL" do
+        connection.add_column_options!(@sql, { :default => { :expr => "ARBITRARY_EXPR" } })
+        @sql.should == "time_taken text DEFAULT ARBITRARY_EXPR"
+      end
+    end
+  end
+end


### PR DESCRIPTION
For example in PostgreSQL it's sometimes desirable to have datetime columns default to the current time, so the database schema should reflect this with default NOW().

The following syntaxes are supported in migrations and schema files and are correctly parsed from the database when dumping the schema:

``` ruby
# default to NOW() in PostgreSQL, DATETIME('now') in SQLite  and raises 
# an exception in MySQL as MySQL does not support this in DATETIME columns
:default => :now

# use arbitrary SQL for databases that allow it
:default => { :expr => 'ARBITRARY_SQL' }

# same as :default => :now
:default => { :expr => :now }

# same as standard :default => 'value' behaviour
:default => { :value => 'standard default value' }
```

In MySQL there is no clear way to achieve these defaults using a DATETIME column. Perhaps support for the TIMESTAMP column could be added in the future which allows the default of CURRENT_TIMESTAMP, but this is out of the scope of this patch.
