### PR TITLE
Fixed regression causing :default => false to be ignored

### DIFF
--- a/lib/schema_plus/active_record/connection_adapters/abstract_adapter.rb
+++ b/lib/schema_plus/active_record/connection_adapters/abstract_adapter.rb
@@ -135,7 +135,7 @@ module SchemaPlus
               raise ArgumentError, "Invalid default expression" unless default_expr_valid?(expr)
               sql << " DEFAULT #{expr}"
             else
-              sql << " DEFAULT #{quote(value, options[:column])}" if value
+              sql << " DEFAULT #{quote(value, options[:column])}" unless value.nil?
             end
           end
           # must explicitly check for :null to allow change_column to work on migrations

--- a/spec/column_definition_spec.rb
+++ b/spec/column_definition_spec.rb
@@ -8,96 +8,127 @@ describe "Column definition" do
 
   let(:connection) { ActiveRecord::Base.connection }
 
-  before(:each) do
-    @sql = 'time_taken text'
-  end
-
-  context "just default passed" do
+  context "text columns" do
     before(:each) do
-      connection.add_column_options!(@sql, { :default => "2011-12-11 00:00:00" })
+      @sql = 'time_taken text'
     end
 
-    subject { @sql}
+    context "just default passed" do
+      before(:each) do
+        connection.add_column_options!(@sql, { :default => "2011-12-11 00:00:00" })
+      end
 
-    it "should use the normal default" do
-      should == "time_taken text DEFAULT '2011-12-11 00:00:00'"
+      subject { @sql}
+
+      it "should use the normal default" do
+        should == "time_taken text DEFAULT '2011-12-11 00:00:00'"
+      end
     end
 
+    context "just default passed in hash" do
+      before(:each) do
+        connection.add_column_options!(@sql, { :default => { :value => "2011-12-11 00:00:00" } })
+      end
+
+      subject { @sql}
+
+      it "should use the normal default" do
+        should == "time_taken text DEFAULT '2011-12-11 00:00:00'"
+      end
+    end
+
+    context "default function passed as now" do
+      before(:each) do
+        begin
+          connection.add_column_options!(@sql, { :default => :now })
+        rescue ArgumentError => e
+          @raised_argument_error = e
+        end
+      end
+
+      subject { @sql }
+
+      if SchemaPlusHelpers.postgresql?
+        it "should use NOW() as the default" do
+          should == "time_taken text DEFAULT NOW()"
+        end
+      end
+
+      if SchemaPlusHelpers.sqlite3?
+        it "should use NOW() as the default" do
+          should == "time_taken text DEFAULT (DATETIME('now'))"
+        end
+      end
+
+      if SchemaPlusHelpers.mysql?
+        it "should raise an error" do
+          @raised_argument_error.should be_a ArgumentError
+        end
+      end
+    end
+
+    context "valid expr passed as default" do
+      subject { connection.add_column_options!(@sql, { :default => { :expr => 'NOW()' } }); @sql }
+
+      if SchemaPlusHelpers.postgresql?
+        it "should use NOW() as the default" do
+          should == "time_taken text DEFAULT NOW()"
+        end
+      end
+
+      if SchemaPlusHelpers.sqlite3?
+        it "should use NOW() as the default" do
+          should == "time_taken text DEFAULT NOW()"
+        end
+      end
+
+      if SchemaPlusHelpers.mysql?
+        it "should raise an error" do
+          lambda { subject }.should raise_error
+        end
+      end
+    end
+
+    context "invalid expr passed as default" do
+      if SchemaPlusHelpers.mysql?
+        it "should raise an error" do
+          lambda {connection.add_column_options!(@sql, { :default => { :expr => "ARBITRARY_EXPR" } })}.should raise_error ArgumentError
+        end
+      else
+        it "should just accept the SQL" do
+          connection.add_column_options!(@sql, { :default => { :expr => "ARBITRARY_EXPR" } })
+          @sql.should == "time_taken text DEFAULT ARBITRARY_EXPR"
+        end
+      end
+    end
   end
 
-  context "just default passed in hash" do
+  context "boolean column" do
     before(:each) do
-      connection.add_column_options!(@sql, { :default => { :value => "2011-12-11 00:00:00" } })
+      @sql = 'time_taken boolean'
     end
 
-    subject { @sql}
+    context "passed as boolean false" do
+      before(:each) do
+        connection.add_column_options!(@sql, { :default => false })
+      end
 
-    it "should use the normal default" do
-      should == "time_taken text DEFAULT '2011-12-11 00:00:00'"
-    end
-  end
+      subject { @sql}
 
-  context "default function passed as now" do
-    before(:each) do
-      begin
-        connection.add_column_options!(@sql, { :default => :now })
-      rescue ArgumentError => e
-        @raised_argument_error = e
+      it "should give the default as false" do
+        should match /boolean DEFAULT (\'f\'|0)/
       end
     end
 
-    subject { @sql }
-
-    if SchemaPlusHelpers.postgresql?
-      it "should use NOW() as the default" do
-        should == "time_taken text DEFAULT NOW()"
+    context "passed as boolean true" do
+      before(:each) do
+        connection.add_column_options!(@sql, { :default => true })
       end
-    end
 
-    if SchemaPlusHelpers.sqlite3?
-      it "should use NOW() as the default" do
-        should == "time_taken text DEFAULT (DATETIME('now'))"
-      end
-    end
+      subject { @sql}
 
-    if SchemaPlusHelpers.mysql?
-      it "should raise an error" do
-        @raised_argument_error.should be_a ArgumentError
-      end
-    end
-  end
-
-  context "valid expr passed as default" do
-    subject { connection.add_column_options!(@sql, { :default => { :expr => 'NOW()' } }); @sql }
-
-    if SchemaPlusHelpers.postgresql?
-      it "should use NOW() as the default" do
-        should == "time_taken text DEFAULT NOW()"
-      end
-    end
-
-    if SchemaPlusHelpers.sqlite3?
-      it "should use NOW() as the default" do
-        should == "time_taken text DEFAULT NOW()"
-      end
-    end
-
-    if SchemaPlusHelpers.mysql?
-      it "should raise an error" do
-        lambda { subject }.should raise_error
-      end
-    end
-  end
-
-  context "invalid expr passed as default" do
-    if SchemaPlusHelpers.mysql?
-      it "should raise an error" do
-        lambda {connection.add_column_options!(@sql, { :default => { :expr => "ARBITRARY_EXPR" } })}.should raise_error ArgumentError
-      end
-    else
-      it "should just accept the SQL" do
-        connection.add_column_options!(@sql, { :default => { :expr => "ARBITRARY_EXPR" } })
-        @sql.should == "time_taken text DEFAULT ARBITRARY_EXPR"
+      it "should give the default as true" do
+        should match /boolean DEFAULT (\'t\'|1)/
       end
     end
   end


### PR DESCRIPTION
For example

```
t.boolean  "finalized", :default => false
```

would result in column SQL like:

```
finalized boolean
```

but should be and now is:

```
finalized boolean DEFAULT 'f'
```
