### PR TITLE
Fixes for postgres index type and expression support

### DIFF
--- a/lib/schema_plus/active_record/connection_adapters/postgresql_adapter.rb
+++ b/lib/schema_plus/active_record/connection_adapters/postgresql_adapter.rb
@@ -77,8 +77,11 @@ module SchemaPlus
           kind       = options[:kind]
 
           if expression = options[:expression] then
-            expression = "USING #{kind} (#{expression})" if kind
+            # Wrap expression in parentheses if necessary
+            expression = "(#{expression})" if expression !~ /(using|with|tablespace|where)/i
+            expression = "USING #{kind} #{expression}" if kind
             expression = "#{expression} WHERE #{conditions}" if conditions
+
             sql = "CREATE #{index_type} INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} #{expression}"
           else
             quoted_column_names = column_names.map { |e| options[:case_sensitive] == false && e.to_s !~ /_id$/ ? "LOWER(#{quote_column_name(e)})" : quote_column_name(e) }

--- a/spec/index_spec.rb
+++ b/spec/index_spec.rb
@@ -74,8 +74,13 @@ describe "add_index" do
 
     it "should allow to specify kind" do
       add_index(:users, :login, :kind => "hash")
-      @index = User.indexes.detect { |i| i.expression.present? }
       index_for(:login).kind.should == 'hash'
+    end
+
+    it "should allow to specify actual expression only" do
+      add_index(:users, :expression => "upper(login)", :name => 'users_login_index')
+      @index = User.indexes.detect { |i| i.expression.present? }
+      @index.expression.should == "upper((login)::text)"
     end
 
     it "should raise if no column given and expression is missing" do


### PR DESCRIPTION
There is currently a problem if you want to use a non-default index type in postgres. If you do

`add_index(:users, :expression => "USING hash (upper(login))", :name => 'users_login_index')`

it will be created fine, but the schema dumper will generate a line with a :kind attribute:

`add_index :users, :kind => 'hash', :expression => 'upper((login)::text)', :name => 'users_login_index'`

and the attribute will be ignored if you try to load the generated schema, the SQL will look something like:

`CREATE  INDEX "users_login_index" ON "users" upper((login)::text)`

Also if you just do 

`add_index(:users, :expression => 'upper(login)', :name => 'users_login_index')` 

it will generate the same SQL, but in this case it just needs to wrap the expression in parentheses (otherwise the query fails).

This PR should fix both issues.
