### PR TITLE
Sort FKs in dump

### DIFF
--- a/lib/schema_plus/active_record/schema_dumper.rb
+++ b/lib/schema_plus/active_record/schema_dumper.rb
@@ -133,7 +133,7 @@ module SchemaPlus
       end
 
       def dump_foreign_keys(foreign_keys, opts={}) #:nodoc:
-        foreign_keys.collect{ |foreign_key| "  " + foreign_key.to_dump(:inline => opts[:inline]) }.join
+        foreign_keys.collect{ |foreign_key| "  " + foreign_key.to_dump(:inline => opts[:inline]) }.sort.join
       end
     end
   end


### PR DESCRIPTION
On our project with multiple dev machines we often have deltas on our schema.rb file which are nothing more than ordering changes of the FKs. This simply sorts them in the dump.
