### PR TITLE
Fix schema dumper with complex expressions

### DIFF
--- a/lib/schema_plus/active_record/schema_dumper.rb
+++ b/lib/schema_plus/active_record/schema_dumper.rb
@@ -101,7 +101,7 @@ module SchemaPlus
         stream_string = stream.string
         @connection.columns(table).each do |column|
           if !column.default_expr.nil?
-            stream_string.gsub!("\"#{column.name}\"", "\"#{column.name}\", :default => { :expr => \"#{column.default_expr}\" }")
+            stream_string.gsub!("\"#{column.name}\"", "\"#{column.name}\", :default => { :expr => #{column.default_expr.inspect} }")
           end
         end
         @table_dumps[table] = stream_string

--- a/spec/schema_dumper_spec.rb
+++ b/spec/schema_dumper_spec.rb
@@ -94,6 +94,12 @@ describe "Schema dump" do
           dump_posts.should match(%r{t.datetime "posted_at",\s*:default => '2001-09-28 00:00:00'})
         end
       end
+
+      it "can dump a complex default expression" do
+        with_additional_column Post, :name, :string, :default => {:expr => 'substring(random()::text from 3 for 6)'} do
+          dump_posts.should match(%r{t.string\s+"name", :default => { :expr => "\\"substring\\"\(\(random\(\)\)::text, 3, 6\)" }})
+        end
+      end
     end
 
     if SchemaPlusHelpers.sqlite3?


### PR DESCRIPTION
Previously, these were getting dumped without quote marks being escaped,
leading to syntax errors in the schema.rb.
