### PR TITLE
When renaming tables, rename constraints

### DIFF
--- a/lib/schema_plus/active_record/connection_adapters/abstract_adapter.rb
+++ b/lib/schema_plus/active_record/connection_adapters/abstract_adapter.rb
@@ -113,7 +113,7 @@ module SchemaPlus
             # if the index is on a foreign key constraint
             rename_index(newname, index.name, ForeignKeyDefinition.auto_index_name(newname, index.columns)) if index
             begin
-              add_foreign_key(newname, fk.column_names, fk.references_table_name, fk.references_column_names, :name => newname, :on_update => fk.on_update, :on_delete => fk.on_delete, :deferrable => fk.deferrable)
+              add_foreign_key(newname, fk.column_names, fk.references_table_name, fk.references_column_names, :name => fk.name.sub(/#{oldname}/, newname), :on_update => fk.on_update, :on_delete => fk.on_delete, :deferrable => fk.deferrable)
             rescue NotImplementedError
               # sqlite3 can't add foreign keys, so just skip it
             end


### PR DESCRIPTION
AbstractAdapter currently tries to rename any foreign key constraints to the new name of the table. For tables with more than one constraint, this results in an error like this:

PG::Error: ERROR:  constraint "new_table_name" for relation "new_table_name" already exists
: ALTER TABLE "new_table_name" ADD CONSTRAINT new_table_name FOREIGN KEY ("other_table_id") REFERENCES "other_table" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION

This patch restores the previous behavior of renaming the constraint by substituting the new table name for the old table name in the constraint name.
