### PR TITLE
Accept :length option for index definition

### DIFF
--- a/lib/schema_plus/active_record/connection_adapters/index_definition.rb
+++ b/lib/schema_plus/active_record/connection_adapters/index_definition.rb
@@ -22,7 +22,7 @@ module SchemaPlus
           # same args as add_index(table_name, column_names, options)
           if args.length == 3 and Hash === args.last
             table_name, column_names, options = args + [{}]
-            initialize_without_schema_plus(table_name, options[:name], options[:unique], column_names, options[:lengths], options[:orders])
+            initialize_without_schema_plus(table_name, options[:name], options[:unique], column_names, options[:lengths] || options[:length], options[:orders])
             @conditions = options[:conditions]
             @expression = options[:expression]
             @kind = options[:kind]
@@ -38,7 +38,7 @@ module SchemaPlus
           opts = {}
           opts[:name]           = name unless name.nil?
           opts[:unique]         = unique unless unique.nil?
-          opts[:lengths]        = lengths unless lengths.nil?
+          opts[:length]         = lengths unless lengths.nil?
           opts[:conditions]     = conditions unless conditions.nil?
           opts[:expression]     = expression unless expression.nil?
           opts[:kind]           = kind unless kind.nil?


### PR DESCRIPTION
Index :length option works in migrations, but is ignored when loading schema. Underlying problem is that ActiveRecord IndexDefinition has a struct member named :lengths, but this value is dumped as :length and #add_index expects the option to be specified as :length.

I left schema_plus support for specifying this option as :lengths in tact, although I'm not sure if it previously had any effect since it was passed to #add_index as :lengths.
