### PR TITLE
Circular reference on column object causes SystemStackError when serializing from hash

### DIFF
--- a/spec/column_spec.rb
+++ b/spec/column_spec.rb
@@ -16,7 +16,7 @@ describe "Column" do
     end
     
     it 'Should be JSON serializable' do
-      @login.to_json
+      {example: @login}.to_json.should_not be_empty
     end
   end
 


### PR DESCRIPTION
I'm not sure if this is exactly what is happening in https://github.com/lomba/schema_plus/issues/90, but I was having a problem with my application hanging after requiring the schema_plus gem.  

I tracked it down and figured out that I had a place (actually in the meta_request gem) that was calling `to_json` on a data structure that deep down in it contained a `ActiveRecord::ConnectionAdapters::PostgreSQLColumn` column object.  Looking at that object, I realized that there is a circular reference to the object that causes problems on serialization.

To illustrate the problem.

Without schema_plus, here is the output:

``` ruby
puts User.columns.first.to_json
# {"name":"id","sql_type":"integer","null":false,"limit":null,"precision":null,"scale":null,"type":"integer","default":null,"primary":true,"coder":null}
```

With schema_plus, here is the output:

``` ruby
puts User.columns.first.to_json
# ActiveSupport::JSON::Encoding::CircularReferenceError: object references itself
```

Now, if we put the column in to the hash (as it was in my case), we get

``` ruby
{foo: User.columns.first}.to_json
# SystemStackError
```

This pull request contains a simple unit test that illustrates the problem.
