### PR TITLE
Tiny fix for PostGIS

### DIFF
--- a/lib/schema_plus/active_record/connection_adapters/abstract_adapter.rb
+++ b/lib/schema_plus/active_record/connection_adapters/abstract_adapter.rb
@@ -26,7 +26,7 @@ module SchemaPlus
             # Here we handle this and hopefully futher adapter names
           when /^MySQL/i 
             adapter = 'MysqlAdapter'
-          when 'PostgreSQL' 
+          when 'PostgreSQL', 'PostGIS'
             adapter = 'PostgresqlAdapter'
           when 'SQLite'
             adapter = 'Sqlite3Adapter'

--- a/lib/schema_plus/active_record/connection_adapters/postgresql_adapter.rb
+++ b/lib/schema_plus/active_record/connection_adapters/postgresql_adapter.rb
@@ -222,6 +222,7 @@ module SchemaPlus
         SELECT viewname
           FROM pg_views
          WHERE schemaname = ANY (current_schemas(false))
+           AND schemaname != 'postgis'
           SQL
         end
 


### PR DESCRIPTION
PostGIS doesn't like for any views that it creates to be dropped, even if you promise to recreate them right away.  This patch stops those views from getting into schema.rb, and compensates for the different name for (essentially) the same DB adapter.
