### PR TITLE
[#101] Prevents the automatic creation of an index if auto_index is fals...

### DIFF
--- a/lib/schema_plus/active_record/schema_dumper.rb
+++ b/lib/schema_plus/active_record/schema_dumper.rb
@@ -114,6 +114,7 @@ module SchemaPlus
 
       def dump_indexes(table) #:nodoc:
         @connection.indexes(table).collect{ |index|
+          next if !SchemaPlus.config.foreign_keys.auto_index && (@inline_fks[table].map(&:name).include?(index.name) || @backref_fks[table].map(&:name).include?(index.name))
           dump = "    t.index"
           unless index.columns.blank? 
             dump << " #{index.columns.inspect}, :name => #{index.name.inspect}"


### PR DESCRIPTION
...e and a foreign_key constraint is defined with the same name

Fix for #101