### PR TITLE
Fix schema dump for case insensitive indexes with ids and strings

### DIFF
--- a/lib/schema_plus/active_record/connection_adapters/postgresql_adapter.rb
+++ b/lib/schema_plus/active_record/connection_adapters/postgresql_adapter.rb
@@ -150,8 +150,11 @@ module SchemaPlus
             # case-insensitive index
             if expression
               rexp_lower = %r{\blower\(\(?([^)]+)(\)::text)?\)}
-              if expression.match /^(#{rexp_lower}(, )?)+$/
-                column_names = expression.scan(rexp_lower).map(&:first)
+              if expression.match /\A#{rexp_lower}(?:, #{rexp_lower})*\z/
+                case_insensitive_columns = expression.scan(rexp_lower).map(&:first)
+                column_names = index_keys.map do |index_key|
+                  index_key == '0' ? case_insensitive_columns.shift : columns[index_key]
+                end
                 case_sensitive = false
               end
             end

--- a/spec/schema_dumper_spec.rb
+++ b/spec/schema_dumper_spec.rb
@@ -22,6 +22,8 @@ describe "Schema dump" do
           t.integer :user_id
           t.integer :first_comment_id
           t.string :string_no_default
+          t.integer :short_id
+          t.string :str_short
         end
 
         create_table :comments, :force => true do |t|
@@ -165,6 +167,12 @@ describe "Schema dump" do
     it "should define case insensitive index" do
       with_index Post, [:body, :string_no_default], :case_sensitive => false do
         dump_posts.should match(to_regexp(%q{t.index ["body", "string_no_default"], :name => "index_posts_on_body_and_string_no_default", :case_sensitive => false}))
+      end
+    end
+
+    it "should define case insensitive index with mixed ids and strings" do
+      with_index Post, [:user_id, :str_short, :short_id, :body], :case_sensitive => false do
+        dump_posts.should match(to_regexp(%q{t.index ["user_id", "str_short", "short_id", "body"], :name => "index_posts_on_user_id_and_str_short_and_short_id_and_body", :case_sensitive => false}))
       end
     end
 


### PR DESCRIPTION
- `SchemaPlus::ActiveRecord::ConnectionAdapters::PostgresqlAdapter#indexes`
  had issues with case insensitive indexes that mixed id columns and
  strings - it didn't dump the id columns.
- I added a test to `spec/schema_dumper_spec.rb` to test a particularly
  malicious index that interleaves id columns with non-id columns.  In
  order to get the index name under 63 characters, I added two columns
  with short names to the `Post` table (`str_short` and `short_id`).
- I modified `PostgresqlAdapter#indexes` to have a more robust regex for
  testing expression.  It then extracts a list of case insensitive
  columns and then uses `index_keys` to generate the list of column
  names, extracting the true columns from `columns` and the case
  insensitive expressions from `case_insensitive_columns`.
- It did not escape my notice that there may be issues defining
  case insensitive indexes that mix non-id numeric or binary columns
  with string/text columns, but I chose not to worry about that at
  this time.

Also note that in order to test I modified `schema_plus.gemspec` to specify `"rails", "~> 3.2.14"` (since there are currently issues with `schema_plus` and Rails 4.0.0, and I don't have the chops to get all those fixed) and added `gem 'pg'` to `Gemfile`, but did not include these in the commit.
