### PR TITLE
Fix creation of case insensitive indexes with non-caseable columns

### DIFF
--- a/spec/schema_dumper_spec.rb
+++ b/spec/schema_dumper_spec.rb
@@ -24,6 +24,15 @@ describe "Schema dump" do
           t.string :string_no_default
           t.integer :short_id
           t.string :str_short
+          t.integer :integer_col
+          t.float :float_col
+          t.decimal :decimal_col
+          t.datetime :datetime_col
+          t.timestamp :timestamp_col
+          t.time :time_col
+          t.date :date_col
+          t.binary :binary_col
+          t.boolean :boolean_col
         end
 
         create_table :comments, :force => true do |t|
@@ -82,19 +91,19 @@ describe "Schema dump" do
     if SchemaPlusHelpers.postgresql?
       it "should dump the default hash expr as now()" do
         with_additional_column Post, :posted_at, :datetime, :default => :now do
-          dump_posts.should match(to_regexp(%q{t.datetime "posted_at", :default => \{ :expr => "now()" \}}))
+          dump_posts.should match(%r{t\.datetime\s+"posted_at",\s*(?:default:|:default =>)\s*\{\s*(?:expr:|:expr =>)\s*"now\(\)"\s*\}})
         end
       end
 
       it "should dump the default hash expr as CURRENT_TIMESTAMP" do
         with_additional_column Post, :posted_at, :datetime, :default => {:expr => 'date \'2001-09-28\''} do
-          dump_posts.should match(%r{t.datetime "posted_at",\s*:default => '2001-09-28 00:00:00'})
+          dump_posts.should match(%r{t\.datetime\s+"posted_at",\s*(?:default:|:default =>)\s*'2001-09-28 00:00:00'})
         end
       end
 
       it "can dump a complex default expression" do
         with_additional_column Post, :name, :string, :default => {:expr => 'substring(random()::text from 3 for 6)'} do
-          dump_posts.should match(%r{t.string\s+"name", :default => { :expr => "\\"substring\\"\(\(random\(\)\)::text, 3, 6\)" }})
+          dump_posts.should match(%r{t\.string\s+"name",\s*(?:default:|:default =>)\s*{\s*(?:expr:|:expr =>)\s*"\\"substring\\"\(\(random\(\)\)::text, 3, 6\)"\s*}})
         end
       end
     end
@@ -102,19 +111,19 @@ describe "Schema dump" do
     if SchemaPlusHelpers.sqlite3?
       it "should dump the default hash expr as now" do
         with_additional_column Post, :posted_at, :datetime, :default => :now do
-          dump_posts.should match(to_regexp(%q{t.datetime "posted_at", :default => \{ :expr => "(DATETIME('now'))" \}}))
+          dump_posts.should match(%r{t\.datetime\s+"posted_at",\s*(?:default:|:default =>)\s*\{\s*(?:expr:|:expr =>)\s*"\(DATETIME\('now'\)\)"\s*\}})
         end
       end
 
       it "should dump the default hash expr string as now" do
         with_additional_column Post, :posted_at, :datetime, :default => { :expr => "(DATETIME('now'))" } do
-          dump_posts.should match(to_regexp(%q{t.datetime "posted_at", :default => \{ :expr => "(DATETIME('now'))" \}}))
+          dump_posts.should match(%r{t\.datetime\s+"posted_at",\s*(?:default:|:default =>)\s*\{\s*(?:expr:|:expr =>)\s*"\(DATETIME\('now'\)\)"\s*\}})
         end
       end
 
       it "should dump the default value normally" do
         with_additional_column Post, :posted_at, :string, :default => "now" do
-          dump_posts.should match(%r{t.string  "posted_at",\s*:default => "now"})
+          dump_posts.should match(%r{t\.string\s*"posted_at",\s*(?:default:|:default =>)\s*"now"})
         end
       end
     end
@@ -125,7 +134,7 @@ describe "Schema dump" do
     ActiveRecord::Migration.suppress_messages do
       ActiveRecord::Migration.change_column_default :posts, :string_no_default, nil
     end
-    dump_posts.should match(%r{t.string\s+"string_no_default"\s*$})
+    dump_posts.should match(%r{t\.string\s+"string_no_default"\s*$})
   end
 
   it "should include foreign_key options" do
@@ -173,6 +182,15 @@ describe "Schema dump" do
     it "should define case insensitive index with mixed ids and strings" do
       with_index Post, [:user_id, :str_short, :short_id, :body], :case_sensitive => false do
         dump_posts.should match(to_regexp(%q{t.index ["user_id", "str_short", "short_id", "body"], :name => "index_posts_on_user_id_and_str_short_and_short_id_and_body", :case_sensitive => false}))
+      end
+    end
+
+    [:integer, :float, :decimal, :datetime, :timestamp, :time, :date, :binary, :boolean].each do |col_type|
+      col_name = "#{col_type}_col"
+      it "should define case insensitive index that includes an #{col_type}" do
+        with_index Post, [:user_id, :str_short, col_name, :body], :case_sensitive => false do
+          dump_posts.should match(to_regexp(%Q!t.index ["user_id", "str_short", "#{col_name}", "body"], :name => "index_posts_on_user_id_and_str_short_and_#{col_name}_and_body", :case_sensitive => false!))
+        end
       end
     end
 


### PR DESCRIPTION
- `SchemaPlus::ActiveRecord::ConnectionAdapters::PostgresqlAdapter#add_index`
  had issues creating case insensitive indexes if there were non-caseable
  (i.e. integer, numeric, etc.) columns that didn't end in `_id`.
- I added tests to `spec/schema_dumper_spec.rb` for all of the Rails-defined
  non-caseable column types.  I added columns for each of these types to
  the posts table and then defined the tests for each of these columns
  using iteration.
- The code fix took more work than I initially thought.  It took me a while
  to locate the `#columns` method.  Although the method signature in 3.2.14
  lists a second optional parameter of `name`, it doesn't appear to do
  anything with that parameter and the parameter was removed in 4.0.0.  So
  I filter through the complete list to extract the caseable columns (I
  considered other approaches, but this one balanced out line lengths best
  without refactoring the code massively) and then use that in the test.
  Since this work is only required for case insensitive indexes, I hoisted
  the case insensitive test outside of the `quoted_column_names` enumeration.
- Note that this will produce a change in behavior if users have columns that
  end in `_id` and that are of type `:string` or `:text` - previously these
  columns would have been case sensitive in the index, and now they will be
  case insensitive.
