### PR TITLE
Added support for Rails Edge 4.1.0beta

### DIFF
--- a/lib/schema_plus.rb
+++ b/lib/schema_plus.rb
@@ -125,9 +125,16 @@ module SchemaPlus
     ::ActiveRecord::ConnectionAdapters::SchemaStatements.send(:include, SchemaPlus::ActiveRecord::ConnectionAdapters::SchemaStatements)
     ::ActiveRecord::ConnectionAdapters::TableDefinition.send(:include, SchemaPlus::ActiveRecord::ConnectionAdapters::TableDefinition)
 
-    if ::ActiveRecord::VERSION::MAJOR.to_i >= 4
-      ::ActiveRecord::ConnectionAdapters::AbstractAdapter::SchemaCreation.send(:include, SchemaPlus::ActiveRecord::ConnectionAdapters::AbstractAdapter::SchemaCreation)
+    if "#{::ActiveRecord::VERSION::MAJOR}.#{::ActiveRecord::VERSION::MINOR}".to_r >= "4.1".to_r
+      ::ActiveRecord::ConnectionAdapters::AbstractAdapter::SchemaCreation.send(:include, SchemaPlus::ActiveRecord::ConnectionAdapters::AbstractAdapter::AddColumnOptions)
+    else
+      ::ActiveRecord::ConnectionAdapters::AbstractAdapter.send(:include, SchemaPlus::ActiveRecord::ConnectionAdapters::AbstractAdapter::AddColumnOptions)
     end
+
+    if ::ActiveRecord::VERSION::MAJOR.to_i >= 4
+      ::ActiveRecord::ConnectionAdapters::AbstractAdapter::SchemaCreation.send(:include, SchemaPlus::ActiveRecord::ConnectionAdapters::AbstractAdapter::VisitTableDefinition)
+    end
+
   end
 
   def self.insert #:nodoc:

--- a/lib/schema_plus/active_record/connection_adapters/mysql_adapter.rb
+++ b/lib/schema_plus/active_record/connection_adapters/mysql_adapter.rb
@@ -147,13 +147,15 @@ module SchemaPlus
           sql
         end
 
-        def default_expr_valid?(expr)
-          false # only the TIMESTAMP column accepts SQL column defaults and rails uses DATETIME
-        end
+        module AddColumnOptions
+          def default_expr_valid?(expr)
+            false # only the TIMESTAMP column accepts SQL column defaults and rails uses DATETIME
+          end
 
-        def sql_for_function(function)
-          case function
-          when :now then 'CURRENT_TIMESTAMP'
+          def sql_for_function(function)
+            case function
+            when :now then 'CURRENT_TIMESTAMP'
+            end
           end
         end
 

--- a/lib/schema_plus/active_record/connection_adapters/postgresql_adapter.rb
+++ b/lib/schema_plus/active_record/connection_adapters/postgresql_adapter.rb
@@ -289,14 +289,16 @@ module SchemaPlus
           foreign_keys
         end
 
-        def default_expr_valid?(expr)
-          true # arbitrary sql is okay in PostgreSQL
-        end
+        module AddColumnOptions
+          def default_expr_valid?(expr)
+            true # arbitrary sql is okay in PostgreSQL
+          end
 
-        def sql_for_function(function)
-          case function
-            when :now
-              "NOW()"
+          def sql_for_function(function)
+            case function
+              when :now
+                "NOW()"
+            end
           end
         end
       end

--- a/lib/schema_plus/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/lib/schema_plus/active_record/connection_adapters/sqlite3_adapter.rb
@@ -21,6 +21,7 @@ module SchemaPlus
             alias_method_chain :indexes, :schema_plus
             alias_method_chain :rename_table, :schema_plus
           end
+
           if ::ActiveRecord::VERSION::MAJOR.to_i < 4
             ::ActiveRecord::ConnectionAdapters::SQLiteColumn.send(:include, SQLiteColumn) unless ::ActiveRecord::ConnectionAdapters::SQLiteColumn.include?(SQLiteColumn)
           else
@@ -116,14 +117,16 @@ module SchemaPlus
           foreign_keys
         end
 
-        def default_expr_valid?(expr)
-          true # arbitrary sql is okay
-        end
+        module AddColumnOptions
+          def default_expr_valid?(expr)
+            true # arbitrary sql is okay
+          end
 
-        def sql_for_function(function)
-          case function
-            when :now
-              "(DATETIME('now'))"
+          def sql_for_function(function)
+            case function
+              when :now
+                "(DATETIME('now'))"
+            end
           end
         end
       end

--- a/spec/column_definition_spec.rb
+++ b/spec/column_definition_spec.rb
@@ -23,7 +23,13 @@ describe "Column definition" do
     end
   end
 
-  let(:connection) { ActiveRecord::Base.connection }
+  def call_add_column_options!(*params, &block)
+    if ::ActiveRecord::VERSION::MAJOR >= 4
+      ActiveRecord::Base.connection.schema_creation.send(:add_column_options!, *params, &block)
+    else
+      ActiveRecord::Base.connection.add_column_options!(*params, &block)
+    end
+  end
 
   context "text columns" do
     before(:each) do
@@ -32,7 +38,7 @@ describe "Column definition" do
 
     context "just default passed" do
       before(:each) do
-        connection.add_column_options!(@sql, { :default => "2011-12-11 00:00:00" })
+        call_add_column_options!(@sql, { :default => "2011-12-11 00:00:00" })
       end
 
       subject { @sql}
@@ -44,7 +50,7 @@ describe "Column definition" do
 
     context "just default passed in hash" do
       before(:each) do
-        connection.add_column_options!(@sql, { :default => { :value => "2011-12-11 00:00:00" } })
+        call_add_column_options!(@sql, { :default => { :value => "2011-12-11 00:00:00" } })
       end
 
       subject { @sql}
@@ -54,10 +60,34 @@ describe "Column definition" do
       end
     end
 
+    context "default passed with no nulls" do
+      before(:each) do
+        call_add_column_options!(@sql, { :default => "2011-12-11 00:00:00", null: false })
+      end
+
+      subject { @sql}
+
+      it "should use the normal default" do
+        should == "time_taken text DEFAULT '2011-12-11 00:00:00' NOT NULL"
+      end
+    end
+
+    context "default passed in hash with no nulls" do
+      before(:each) do
+        call_add_column_options!(@sql, { :default => { :value => "2011-12-11 00:00:00" }, null: false })
+      end
+
+      subject { @sql}
+
+      it "should use the normal default" do
+        should == "time_taken text DEFAULT '2011-12-11 00:00:00' NOT NULL"
+      end
+    end
+
     context "default function passed as now" do
       before(:each) do
         begin
-          connection.add_column_options!(@sql, { :default => :now })
+          call_add_column_options!(@sql, { :default => :now })
         rescue ArgumentError => e
           @raised_argument_error = e
         end
@@ -84,8 +114,38 @@ describe "Column definition" do
       end
     end
 
+    context "default function passed as now with no nulls" do
+      before(:each) do
+        begin
+          call_add_column_options!(@sql, { :default => :now, null: false })
+        rescue ArgumentError => e
+          @raised_argument_error = e
+        end
+      end
+
+      subject { @sql }
+
+      if SchemaPlusHelpers.postgresql?
+        it "should use NOW() as the default" do
+          should == "time_taken text DEFAULT NOW() NOT NULL"
+        end
+      end
+
+      if SchemaPlusHelpers.sqlite3?
+        it "should use NOW() as the default" do
+          should == "time_taken text DEFAULT (DATETIME('now')) NOT NULL"
+        end
+      end
+
+      if SchemaPlusHelpers.mysql?
+        it "should raise an error" do
+          @raised_argument_error.should be_a ArgumentError
+        end
+      end
+    end
+
     context "valid expr passed as default" do
-      subject { connection.add_column_options!(@sql, { :default => { :expr => 'NOW()' } }); @sql }
+      subject { call_add_column_options!(@sql, { :default => { :expr => 'NOW()' } }); @sql }
 
       if SchemaPlusHelpers.postgresql?
         it "should use NOW() as the default" do
@@ -109,11 +169,11 @@ describe "Column definition" do
     context "invalid expr passed as default" do
       if SchemaPlusHelpers.mysql?
         it "should raise an error" do
-          lambda {connection.add_column_options!(@sql, { :default => { :expr => "ARBITRARY_EXPR" } })}.should raise_error ArgumentError
+          lambda {call_add_column_options!(@sql, { :default => { :expr => "ARBITRARY_EXPR" } })}.should raise_error ArgumentError
         end
       else
         it "should just accept the SQL" do
-          connection.add_column_options!(@sql, { :default => { :expr => "ARBITRARY_EXPR" } })
+          call_add_column_options!(@sql, { :default => { :expr => "ARBITRARY_EXPR" } })
           @sql.should == "time_taken text DEFAULT ARBITRARY_EXPR"
         end
       end
@@ -127,7 +187,7 @@ describe "Column definition" do
 
     context "passed as boolean false" do
       before(:each) do
-        connection.add_column_options!(@sql, { :default => false })
+        call_add_column_options!(@sql, { :default => false })
       end
 
       subject { @sql}
@@ -139,7 +199,7 @@ describe "Column definition" do
 
     context "passed as boolean true" do
       before(:each) do
-        connection.add_column_options!(@sql, { :default => true })
+        call_add_column_options!(@sql, { :default => true })
       end
 
       subject { @sql}


### PR DESCRIPTION
Refactoring to support the migrations of add_column_options! between
Rails 3.2, 4.0, and 4.1.
- Rails 3.2 uses #aco! in the module AR::CA::SchemaStatements that
  gets included into AR::CA.
- Rails 4.0 uses #aco! in the class AR::CA::AbstractAdapter::SchemaCreation
  to call #aco! against AR::CA which includes #aco! from the module
  AR::CA::SchemaStatements.
- Rails 4.1 does away with the #aco! in AR::CA::SchemaStatements and
  simply implements all of the functionality in the class
  AR::CA::AbstractAdapter::SchemaCreation.

With this in mind, our #aco! (along with the methods upon which it
depends) was moved into its own module which could then be injected
as needed.  In addition, since we need to be able to inject into a
class that directly implements the functionality and to hang on to the
underlying functionality, our #aco! functionality was implemented
using alias_method_chain.
- The module AddColumnOptions was extracted in
  SchemaPlus::ActiveRecord::ConnectionAdapters::AbstractAdapter and
  now includes #add_column_options_with_schema_plus!,
  #default_expr_valid?, and #sql_for_function.  In situations where an
  expression is generated using sql_for_function, our code is 100%
  responsible for making all changes to sql.  In all other situations,
  it punts to add_column_options_without_schema_plus! thus retaining
  base functionality.
- Because #default_expr_valid? and #sql_for_function had to move so
  that #add_column_options_with_schema_plus! could access them when
  it gets added to the SchemaCreation class, the adapter-specific
  modules had to be modified as well to extract those functions into
  new AddColumnOptions modules as well.
- In order to get those new adapter-specific modules injected into
  the correct locations, AbstractAdapter#initialize_with_schema_plus
  was modified to handle that injection and to vary it based on the
  version of Rails.
- SchemaPlus.insert_connection_adapters was modified to inject
  SP::AR::CA::AbstractAdapter::AddColumnOptions into the appropriate
  location depending upon the version of Rails.

To make the #visit_TableDefinition code more similar to the #aco!
implementation, SP::AR::CA::AbstractAdapter::SchemaCreation was
renamed to ::VisitTableDefinition.

Finally, spec/column_definition_spec.rb had to be modified since it
assumed that #aco! was implemented on the connection object, whereas
in Rails 4.1 it has now moved to the new SchemaCreation object (and is
now private).  In addition, there was some missing test coverage due
to not testing the combination of :default with null: false, so those
tests were added.
