### PR TITLE
Support for check constraints. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,18 @@ to address some of these issues.  The Wiki article [Making yaml_db work with
 foreign key constraints in PostgreSQL](https://github.com/lomba/schema_plus/wiki/Making-yaml_db-work-with-foreign-key-constraints-in-PostgreSQL)
 has some information that may be of assistance in resolving these issues.
 
+### Check Constraints
+
+SchemaPlus adds support for check constraints. You can either write check
+constraint expression youself in SQL:
+
+    t.string :type, check: "type = 'mytype'"
+
+Or you can pass an array of possible column values:
+
+    t.string :type, check: ["Type1", "Type2", "Type3"]
+
+
 ### Tables
 
 SchemaPlus extends rails' `drop_table` method to accept these options:

--- a/lib/schema_plus/active_record/column_options_handler.rb
+++ b/lib/schema_plus/active_record/column_options_handler.rb
@@ -19,6 +19,10 @@ module SchemaPlus::ActiveRecord
       end
       column_index(table_name, column_name, index) if index
 
+      # create check constraint on the field if requested explicitly
+      check = column_options[:check]
+      add_column_check_constraint(table_name, column_name, check) if check
+
       if fk_args
         references = fk_args.delete(:references)
         add_foreign_key(table_name, column_name, references.first, references.last, fk_args)

--- a/lib/schema_plus/active_record/connection_adapters/abstract_adapter.rb
+++ b/lib/schema_plus/active_record/connection_adapters/abstract_adapter.rb
@@ -55,6 +55,22 @@ module SchemaPlus
         end
 
 
+        # Create a column check constraint.
+        # Check can be an array of possible values or SQL expression
+        # Note, MySQL does not implement check constraints, but it will accept SQL containing them
+        def add_column_check_constraint(table_name, column_name, check)
+          check_expression = if check.is_a? Array
+            "#{quote_column_name(column_name)} in (#{check.map { |c| quote(c) }.join(", ")})"
+          elsif check.is_a? String
+            check
+          else
+            raise "Invalid column '#{column_name}' check constraint in table '#{table_name}'."
+          end
+
+          execute "ALTER TABLE #{quote_table_name(table_name)} ADD CONSTRAINT check_constraint_#{table_name}_#{column_name} check (#{check_expression})"
+        end
+
+
         # Define a foreign key constraint.  Valid options are :on_update,
         # :on_delete, and :deferrable, with values as described at
         # ConnectionAdapters::ForeignKeyDefinition

--- a/spec/check_constraint_spec.rb
+++ b/spec/check_constraint_spec.rb
@@ -1,0 +1,57 @@
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+
+
+describe "Check constraints" do
+  before(:all) do
+    define_schema(:auto_create => false) do
+      create_table :posts, :force => true do |t|
+        t.text :body
+        t.string :post_type
+        t.string :post_type2
+        t.string :post_type3
+      end
+    end
+    class Post < ::ActiveRecord::Base ; end
+  end
+
+  def call_add_column_check_constraint(*params)
+    ActiveRecord::Base.connection.add_column_check_constraint(*params)
+  end
+
+  if SchemaPlusHelpers.mysql?
+
+    it "should silently skip constraint definition" do
+      call_add_column_check_constraint(:posts, :post_type, ["a", "b", "c"])
+
+      post = Post.create!(body: "body", post_type: "a")
+      post.post_type.should == "a"
+      post = Post.create!(body: "body", post_type: "z")
+      post.post_type.should == "z"
+    end
+
+  else
+
+    it "should generate check constraint for array of possible values" do
+      call_add_column_check_constraint(:posts, :post_type, ["a", "b", "c"])
+
+      post = Post.create!(body: "body", post_type: "a")
+      post.post_type.should == "a"
+
+      expect { Post.create!(body: "body", post_type: "d") }.to raise_error
+      expect { Post.create!(body: "body", post_type: 1) }.to raise_error
+    end
+
+    it "should use string as check constraint expression" do
+      call_add_column_check_constraint(:posts, :post_type2, "post_type2 = 'foo'")
+
+      post = Post.create!(body: "body", post_type2: "foo")
+      post.post_type2.should == "foo"
+    end
+
+    it "should break given wrong constraint" do
+      expect { call_add_column_check_constraint(:posts, :post_type3, {:foo => :bar}) }.to raise_error("Invalid column 'post_type3' check constraint in table 'posts'.")
+    end
+
+  end
+
+end


### PR DESCRIPTION
Hi, 
I missed the ability to define check constraints in Rails migrations syntax. So here's the patch :)

Constraints can be specified as:
- SQL expression, for example:
  t.string :type, check: "type = 'mytype'"
- array of possible column values:
  t.string :type, check: ["Type1", "Type2", "Type3"]
