### PR TITLE
Sort indexes alphabetically, like Rails does.

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ of foreign key constraints, you can re-enable it:
 
 ### Master branch (to be released)
 
-* (nothing new yet)
+* Sort indexes alphabetically when dumping, like rails does
 
 ### 1.3.1
 

--- a/lib/schema_plus/active_record/schema_dumper.rb
+++ b/lib/schema_plus/active_record/schema_dumper.rb
@@ -133,7 +133,7 @@ module SchemaPlus
             dump << ", :expression => #{index.expression.inspect}"
           end
           dump << "\n"
-        }.join
+        }.sort.join
       end
 
       def dump_foreign_keys(foreign_keys, opts={}) #:nodoc:

--- a/spec/schema_dumper_spec.rb
+++ b/spec/schema_dumper_spec.rb
@@ -161,6 +161,14 @@ describe "Schema dump" do
     end
   end
 
+  it "should sort indexes" do
+    with_index Post, :user_id do
+      with_index Post, :short_id do
+        dump_posts.should match(/on_short_id.+on_user_id/m)
+      end
+    end
+  end
+
   unless SchemaPlusHelpers.mysql?
 
     it "should include index order" do


### PR DESCRIPTION
Rails sorts indexes alphabetically when dumping a schema;[<sup>[1]</sup>](https://github.com/rails/rails/blob/be71b0ecbe4b6f2416296dd0c120b652151ebcaa/activerecord/lib/active_record/schema_dumper.rb#L191) it has done this since 2008.[<sup>[2]</sup>](https://rails.lighthouseapp.com/projects/8994/tickets/1266-order-add_index-statements-in-schemarb)

The members of our team have indexes in different orders, depending on when they created their databases by loading the schema and how many migrations they've run chronologically since then.  Thus, when we started using schema_plus, we all started dumping our schemas with different index orders, which led to a lot of spurious git diffs.

I considered just making a migration to change the ordering of the indexes for everyone.  But, I figured it would be better to make schema_plus behave the same way that Rails has since 2008.  Feel free to close this pull request if you disagree!
