### PR TITLE
Remove GEM_PATH line 93 from runspecs?

### DIFF
--- a/runspecs
+++ b/runspecs
@@ -90,7 +90,7 @@ else
     # strip those out so that the forked shell can run a diifferent ruby
     # version than the one we're in now.
     ENV['PATH'] = ENV['PATH'].split(':').reject{|dir| dir =~ %r{/rbenv/(?!shims)}}.join(':')
-    ENV['GEM_PATH'] = ENV['GEM_PATH'].split(':').reject{|dir| dir =~ %r{/rbenv}}.join(':')
+    ENV['GEM_PATH'] = ENV['GEM_PATH'].split(':').reject{|dir| dir =~ %r{/rbenv}}.join(':') unless ENV['GEM_PATH'].nil?
     ENV['RBENV_DIR'] = nil
     ENV['RBENV_HOOK_PATH'] = nil
 


### PR DESCRIPTION
I am using rbenv 0.4.0 (current) on OSX.  When I run the runspecs command, it produces this error:

<pre>$ ./runspecs --quick
./runspecs:93:in `<main>': undefined method `split' for nil:NilClass (NoMethodError)</pre>


Line 93 is:

<pre>    ENV['GEM_PATH'] = ENV['GEM_PATH'].split(':').reject{|dir| dir =~ %r{/rbenv}}.join(':')</pre>


The problem is that ENV['GEM_PATH'] is nil.  According to the comment above this section of the code, it applies to rbenv, but rbenv doesn't set that variable.  I searched the rbenv project for GEM_PATH and got no hits, so I don't think it ever uses that environment variable: https://github.com/sstephenson/rbenv/search?q=GEM_PATH&type=Code

When I comment out the line, runspecs runs to completion.

Can this line just be removed?
