### PR TITLE
Allow for hidden rbenv directory.

### DIFF
--- a/runspecs
+++ b/runspecs
@@ -89,8 +89,8 @@ else
     # rbenv, we already have various environment variables set up.  need
     # strip those out so that the forked shell can run a diifferent ruby
     # version than the one we're in now.
-    ENV['PATH'] = ENV['PATH'].split(':').reject{|dir| dir =~ %r{/rbenv/(?!shims)}}.join(':')
-    ENV['GEM_PATH'] = ENV['GEM_PATH'].split(':').reject{|dir| dir =~ %r{/rbenv}}.join(':') unless ENV['GEM_PATH'].nil?
+    ENV['PATH'] = ENV['PATH'].split(':').reject{|dir| dir =~ %r{/\.?rbenv/(?!shims)}}.join(':')
+    ENV['GEM_PATH'] = ENV['GEM_PATH'].split(':').reject{|dir| dir =~ %r{/\.?rbenv}}.join(':') unless ENV['GEM_PATH'].nil?
     ENV['RBENV_DIR'] = nil
     ENV['RBENV_HOOK_PATH'] = nil
 


### PR DESCRIPTION
In runspecs, allow the forked shell to run a different ruby version even if the rbenv directory is hidden, i.e. .rbenv.
