### PR TITLE
fixing MSSQL errors ..not a fully 100% adapter

### DIFF
--- a/lib/schema_plus.rb
+++ b/lib/schema_plus.rb
@@ -24,6 +24,7 @@ module SchemaPlus
       autoload :PostgresqlAdapter, 'schema_plus/active_record/connection_adapters/postgresql_adapter'
       autoload :PostgreSQLColumn, 'schema_plus/active_record/connection_adapters/postgresql_adapter'
       autoload :Sqlite3Adapter, 'schema_plus/active_record/connection_adapters/sqlite3_adapter'
+      autoload :MssqlAdapter, 'schema_plus/active_record/connection_adapters/mssql_adapter'
     end
   end
 

--- a/lib/schema_plus/active_record/connection_adapters/abstract_adapter.rb
+++ b/lib/schema_plus/active_record/connection_adapters/abstract_adapter.rb
@@ -26,6 +26,7 @@ module SchemaPlus
                     when /^MySQL/i                 then 'MysqlAdapter'
                     when 'PostgreSQL', 'PostGIS'   then 'PostgresqlAdapter'
                     when 'SQLite'                  then 'Sqlite3Adapter'
+                    when 'MSSQL','jbdcmssql'       then 'MssqlAdapter'
                     end
           if adapter.nil?
             unless adapter_name == 'JDBC' # ARJDBC

--- a/lib/schema_plus/active_record/connection_adapters/mssql_adapter.rb
+++ b/lib/schema_plus/active_record/connection_adapters/mssql_adapter.rb
@@ -1,0 +1,21 @@
+module SchemaPlus
+  module ActiveRecord
+    module ConnectionAdapters
+      # SchemaPlus includes a MySQL implementation of the AbstractAdapter
+      # extensions.  (This works with both the <tt>mysql</t> and
+      # <tt>mysql2</tt> gems.)
+      module MssqlAdapter
+        module AddColumnOptions
+          def default_expr_valid?(expr)
+            false # only the TIMESTAMP column accepts SQL column defaults and rails uses DATETIME
+          end
+          def sql_for_function(function)
+            case function
+            when :now then 'GETDATE()'
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allowed schema plus to run using MSSQL and fix an error with regards to "sql for function"