### PR TITLE
:name on foreign_key definition was being ignored

### DIFF
--- a/lib/schema_plus/active_record/column_options_handler.rb
+++ b/lib/schema_plus/active_record/column_options_handler.rb
@@ -15,8 +15,12 @@ module SchemaPlus::ActiveRecord
       # create index if requested explicity or implicitly due to auto_index
       index = column_options[:index]
       index = column_options[:_index] if column_options.include? :_index
-      if index.nil? and fk_args && config.foreign_keys.auto_index?
-        index = { :name => auto_index_name(table_name, column_name) }
+      if index.nil? and fk_args
+        if fk_args[:name]
+          index = { :name => fk_args[:name] }
+        elsif config.foreign_keys.auto_index?
+          index = { :name => auto_index_name(table_name, column_name) }
+        end
       end
       column_index(table_name, column_name, index) if index
 


### PR DESCRIPTION
Postgres has a length limit on foreign_key names so I needed to specify the name of my key to make it shorter. Doing the following would not work because the :name parameter was being ignored.

t.integer :group_id, foreign_key: { references: :inventory_transaction_groups, name: 'fk_work_order_transaction_groups' }
