### PR TITLE
support activerecord-postgis-adapter

### DIFF
--- a/lib/schema_plus.rb
+++ b/lib/schema_plus.rb
@@ -123,6 +123,7 @@ module SchemaPlus
     ::ActiveRecord::ConnectionAdapters::AbstractAdapter.send(:include, SchemaPlus::ActiveRecord::ConnectionAdapters::AbstractAdapter)
     ::ActiveRecord::ConnectionAdapters::Column.send(:include, SchemaPlus::ActiveRecord::ConnectionAdapters::Column)
     ::ActiveRecord::ConnectionAdapters::IndexDefinition.send(:include, SchemaPlus::ActiveRecord::ConnectionAdapters::IndexDefinition)
+    RGeo::ActiveRecord::SpatialIndexDefinition.send(:include, SchemaPlus::ActiveRecord::ConnectionAdapters::IndexDefinition) if defined?(RGeo::ActiveRecord::SpatialIndexDefinition)
     ::ActiveRecord::ConnectionAdapters::SchemaStatements.send(:include, SchemaPlus::ActiveRecord::ConnectionAdapters::SchemaStatements)
     ::ActiveRecord::ConnectionAdapters::TableDefinition.send(:include, SchemaPlus::ActiveRecord::ConnectionAdapters::TableDefinition)
     ::ActiveRecord::Migration::CommandRecorder.send(:include, SchemaPlus::ActiveRecord::Migration::CommandRecorder)


### PR DESCRIPTION
activerecord-postgis-adapter defines its own index class, something like this is required either on schema_plus side or activerecord-postgis-adapter side to make schema_plus and activerecord-postgis-adapter play well together.