### PR TITLE
Require 'active_record' in root file

### DIFF
--- a/lib/schema_plus.rb
+++ b/lib/schema_plus.rb
@@ -1,3 +1,4 @@
+require 'active_record'
 require 'valuable'
 
 require 'schema_plus/version'


### PR DESCRIPTION
I'm using ActiveRecord 4.1 with Padrino, and including `schema_plus` causes the application to raise a `NameError` on ActiveRecord:

```
/Users/thmzlt/.gem/ruby/2.1.5/gems/schema_plus-1.7.1/lib/schema_plus/active_record/connection_adapters/table_definition.rb:96:in `<module:TableDefinition>': uninitialized constant ActiveRecord (NameError)
        from /Users/thmzlt/.gem/ruby/2.1.5/gems/schema_plus-1.7.1/lib/schema_plus/active_record/connection_adapters/table_definition.rb:66:in `<module:ConnectionAdapters>'
        from /Users/thmzlt/.gem/ruby/2.1.5/gems/schema_plus-1.7.1/lib/schema_plus/active_record/connection_adapters/table_definition.rb:1:in `<top (required)>'
        from /Users/thmzlt/.gem/ruby/2.1.5/gems/schema_plus-1.7.1/lib/schema_plus.rb:8:in `require'
        from /Users/thmzlt/.gem/ruby/2.1.5/gems/schema_plus-1.7.1/lib/schema_plus.rb:8:in `<top (required)>'
        from /Users/thmzlt/.gem/ruby/2.1.5/gems/bundler-1.7.7/lib/bundler/runtime.rb:76:in `require'
        from /Users/thmzlt/.gem/ruby/2.1.5/gems/bundler-1.7.7/lib/bundler/runtime.rb:76:in `block (2 levels) in require'
        from /Users/thmzlt/.gem/ruby/2.1.5/gems/bundler-1.7.7/lib/bundler/runtime.rb:72:in `each'
        from /Users/thmzlt/.gem/ruby/2.1.5/gems/bundler-1.7.7/lib/bundler/runtime.rb:72:in `block in require'
        from /Users/thmzlt/.gem/ruby/2.1.5/gems/bundler-1.7.7/lib/bundler/runtime.rb:61:in `each'
        from /Users/thmzlt/.gem/ruby/2.1.5/gems/bundler-1.7.7/lib/bundler/runtime.rb:61:in `require'
        from /Users/thmzlt/.gem/ruby/2.1.5/gems/bundler-1.7.7/lib/bundler.rb:133:in `require'
        from /Users/thmzlt/Code/myapp/config/boot.rb:8:in `<top (required)>'
        from /Users/thmzlt/.gem/ruby/2.1.5/bundler/gems/padrino-framework-4692b60b2a33/padrino-core/lib/padrino-core/cli/base.rb:37:in `require'
        from /Users/thmzlt/.gem/ruby/2.1.5/bundler/gems/padrino-framework-4692b60b2a33/padrino-core/lib/padrino-core/cli/base.rb:37:in `console'
        from /Users/thmzlt/.gem/ruby/2.1.5/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
        from /Users/thmzlt/.gem/ruby/2.1.5/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
        from /Users/thmzlt/.gem/ruby/2.1.5/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
        from /Users/thmzlt/.gem/ruby/2.1.5/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
        from /Users/thmzlt/.gem/ruby/2.1.5/bundler/gems/padrino-framework-4692b60b2a33/padrino-core/bin/padrino:8:in `<top (required)>'
        from /Users/thmzlt/.gem/ruby/2.1.5/bin/padrino:23:in `load'
        from /Users/thmzlt/.gem/ruby/2.1.5/bin/padrino:23:in `<main>'
```

This change change fixes the error.
