### PR TITLE
Duplicate the given options from the migration instead of modifying in place

### DIFF
--- a/lib/schema_plus/active_record/column_options_handler.rb
+++ b/lib/schema_plus/active_record/column_options_handler.rb
@@ -49,6 +49,7 @@ module SchemaPlus::ActiveRecord
 
       if column_options.has_key?(:foreign_key)
         args = column_options[:foreign_key]
+        args = args.dup if args.is_a?(Hash)
         return :none unless args
         args = {} if args == true
         return :none if args.has_key?(:references) and not args[:references]
@@ -93,6 +94,7 @@ module SchemaPlus::ActiveRecord
 
 
     def column_index(table_name, column_name, options) #:nodoc:
+      options = options.dup
       column_name = [column_name] + Array.wrap(options.delete(:with)).compact
       add_index(table_name, column_name, options)
     end

--- a/lib/schema_plus/active_record/connection_adapters/schema_statements.rb
+++ b/lib/schema_plus/active_record/connection_adapters/schema_statements.rb
@@ -40,6 +40,7 @@ module SchemaPlus::ActiveRecord::ConnectionAdapters
     end
 
     def add_index_options_with_schema_plus(table_name, column_name, options = {})
+      options = options.dup
       columns = options.delete(:with) { |_| [] }
       add_index_options_without_schema_plus(table_name, Array(column_name).concat(Array(columns).map(&:to_s)), options)
     end

--- a/spec/migration_spec.rb
+++ b/spec/migration_spec.rb
@@ -70,6 +70,24 @@ describe ActiveRecord::Migration do
       expect(@model).to reference(:users, :id).on(:author_id)
     end
 
+    it "should create foreign key without modifying input hash" do
+      hash = { :references => :users }
+      hash_original = hash.dup
+      recreate_table(@model) do |t|
+        t.integer :author_id, :foreign_key => hash
+      end
+      expect(hash).to eq(hash_original)
+    end
+
+    it "should create foreign key without modifying input hash" do
+      hash = { :references => :users }
+      hash_original = hash.dup
+      recreate_table(@model) do |t|
+        t.references :author, :foreign_key => hash
+      end
+      expect(hash).to eq(hash_original)
+    end
+
     it "should create foreign key with different reference using shortcut" do
       recreate_table(@model) do |t|
         t.integer :author_id, :references => :users
@@ -248,6 +266,16 @@ describe ActiveRecord::Migration do
         t.integer :state,       :index => { :with => :city }
       end
       expect(@model).to have_index.on([:state, :city])
+    end
+
+    it "should create the index without modifying the input hash" do
+      hash = { :with => :foo, :length => { :foo => 8, :bar => 12 }}
+      hash_original = hash.dup
+      recreate_table(@model) do |t|
+        t.string :foo
+        t.string :bar, :index => hash
+      end
+      expect(hash).to eq(hash_original)
     end
 
     it "should auto-index foreign keys only" do


### PR DESCRIPTION
This allows the same options to be used by different parts of the migration script, e.g.

```ruby
hash = { references: :users }
t.references :creator, foreign_key: hash
t.references :updater, foreign_key: hash
```

Which would be invalid otherwise.