### PR TITLE
Add options[:_index] to `schema_plus_normalize_column_options`.

### DIFF
--- a/lib/schema_plus/active_record/column_options_handler.rb
+++ b/lib/schema_plus/active_record/column_options_handler.rb
@@ -2,17 +2,19 @@ module SchemaPlus::ActiveRecord
   module ColumnOptionsHandler
     def schema_plus_normalize_column_options(options)
       # replace some shortcuts with full versions
-      case options[:index]
-      when true then options[:index] = {}
-      when :unique then options[:index] = { :unique => true }
-      when Hash
-        if options[:index][:length].is_a? Hash
-          normalize = if "#{::ActiveRecord::VERSION::MAJOR}.#{::ActiveRecord::VERSION::MINOR}".to_r >= "4.2".to_r
-                        :stringify_keys!
-                      else
-                        :symbolize_keys!
-                      end
-          options[:index][:length].send normalize
+      [:index, :_index].each do |key|
+        case options[key]
+        when true then options[key] = {}
+        when :unique then options[key] = { :unique => true }
+        when Hash
+          if options[key][:length].is_a? Hash
+            normalize = if "#{::ActiveRecord::VERSION::MAJOR}.#{::ActiveRecord::VERSION::MINOR}".to_r >= "4.2".to_r
+                          :stringify_keys!
+                        else
+                          :symbolize_keys!
+                        end
+            options[key][:length].send normalize
+          end
         end
       end
     end

--- a/spec/foreign_key_spec.rb
+++ b/spec/foreign_key_spec.rb
@@ -73,6 +73,10 @@ describe "Foreign Key" do
           t.integer :post_id
           t.foreign_key :post_id, :posts, :id
         end
+
+        change_table :comments do |t|
+          t.references :user, :index => true
+        end
       end
       class User < ::ActiveRecord::Base ; end
       class Post < ::ActiveRecord::Base ; end


### PR DESCRIPTION
This solves a problem we were seeing with using `t.references :foo, :index => true`. It broke between schema_plus 1.7.1 and 1.8.1.