### PR TITLE
Move all backref foreign_key definitions at the bottom of schema.rb

### DIFF
--- a/lib/schema_plus/active_record/connection_adapters/schema_statements.rb
+++ b/lib/schema_plus/active_record/connection_adapters/schema_statements.rb
@@ -46,10 +46,11 @@ module SchemaPlus::ActiveRecord::ConnectionAdapters
     end
 
     def self.add_index_exception_handler(connection, table, columns, options, e) #:nodoc:
-      raise unless e.message.match(/["']([^"']+)["'].*already exists/)
+      raise unless e.message.match(/already exists|DuplicateTable/)
+      e.message.match(/["']([^"']+)["'].*/)
       name = $1
       existing = connection.indexes(table).find{|i| i.name == name}
-      attempted = ::ActiveRecord::ConnectionAdapters::IndexDefinition.new(table, columns, options.merge(:name => name)) 
+      attempted = ::ActiveRecord::ConnectionAdapters::IndexDefinition.new(table, columns, options.merge(:name => name))
       raise if attempted != existing
       ::ActiveRecord::Base.logger.warn "[schema_plus] Index name #{name.inspect}' on table #{table.inspect} already exists. Skipping."
     end

--- a/spec/named_schemas_spec.rb
+++ b/spec/named_schemas_spec.rb
@@ -14,7 +14,7 @@ describe "with multiple schemas" do
     begin
       ActiveRecord::Base.connection.execute newdb
     rescue ActiveRecord::StatementInvalid => e
-      raise unless e.message =~ /already exists/
+      raise unless e.message =~ /already exists|DuplicateSchema/
     end
 
     class User < ::ActiveRecord::Base ; end
@@ -184,7 +184,7 @@ describe "with multiple schemas" do
       begin
         connection.execute "CREATE SCHEMA postgis"
       rescue ActiveRecord::StatementInvalid => e
-        raise unless e.message =~ /already exists/
+        raise unless e.message =~ /already exists|DuplicateSchema/
       end
     end
 

--- a/spec/schema_dumper_spec.rb
+++ b/spec/schema_dumper_spec.rb
@@ -160,7 +160,7 @@ describe "Schema dump" do
       expect(dump_posts).to match(to_regexp(%q{t.index ["user_id"], :name => "custom_name"}))
     end
   end
-  
+
   it "should define unique index" do
     with_index Post, :user_id, :name => "posts_user_id_index", :unique => true do
       expect(dump_posts).to match(to_regexp(%q{t.index ["user_id"], :name => "posts_user_id_index", :unique => true}))
@@ -277,6 +277,12 @@ describe "Schema dump" do
       expect(dump_schema).to match(%r{create_table "posts".*foreign_key.*\["post_id"\], "posts", \["id"\]}m)
       expect(dump_schema).to match(%r{create_table "users".*foreign_key.*\["commenter_id"\], "users", \["id"\]}m)
       expect(dump_schema).to match(%r{create_table "users".*foreign_key.*\["user_id"\], "users", \["id"\]}m)
+    end
+
+    it "should dump constraints after all table definitions" do
+      expect(dump_schema).to match(%r{create_table "users".*foreign_key.*\["post_id"\], "posts", \["id"\]}m)
+      expect(dump_schema).to match(%r{foreign_key.*\["post_id"\], "posts", \["id"\].*foreign_key.*\["commenter_id"\], "users", \["id"\]}m)
+      expect(dump_schema).to match(%r{foreign_key.*\["commenter_id"\], "users", \["id"\].*foreign_key.*\["user_id"\], "users", \["id"\]}m)
     end
   end
 


### PR DESCRIPTION
Sometimes in complicated DB's schemas may be situation when add_foreign_key definition appears before one of the involved table is defined, and consequently schema load fails.

