### PR TITLE
Fix postgres schema dumping in 1.x when using case_sensitive => false and operator_class together

### DIFF
--- a/lib/schema_plus/active_record/connection_adapters/postgresql_adapter.rb
+++ b/lib/schema_plus/active_record/connection_adapters/postgresql_adapter.rb
@@ -218,8 +218,8 @@ module SchemaPlus
               opclass_name[oid.to_s] = opcname
             end
             operator_classes = {}
-            index_keys.zip(opclasses).each do |index_key, opclass|
-              operator_classes[columns[index_key]] = opclass_name[opclass]
+            column_names.zip(opclasses).each do |column_name, opclass|
+              operator_classes[column_name] = opclass_name[opclass]
             end
             operator_classes.delete_if{|k,v| v.nil?}
 

--- a/spec/schema_dumper_spec.rb
+++ b/spec/schema_dumper_spec.rb
@@ -229,6 +229,12 @@ describe "Schema dump" do
       end
     end
 
+    it 'should dump proper operator_class with case_sensitive => false' do
+      with_index Post, :body, :operator_class => 'text_pattern_ops', :case_sensitive => false do
+        expect(dump_posts).to match(to_regexp(%q{t.index ["body"], :name => "index_posts_on_body", :case_sensitive => false, :operator_class => {"body" => "text_pattern_ops"}}))
+      end
+    end
+    
     it "should dump unique: true with expression (Issue #142)" do
       with_index Post, :name => "posts_user_body_index", :unique => true, :expression => "BTRIM(LOWER(body))" do
         expect(dump_posts).to match(%r{#{to_regexp(%q{t.index :name => "posts_user_body_index", :unique => true, :expression => "btrim(lower(body))"})}$})


### PR DESCRIPTION
Fixes a bug whereby a migration line like:

```
add_index :users, :name, :case_sensitive => false, :operator_class => 'text_pattern_ops', :name => :usernamelower
```

migrates properly, but results in a schema.rb line like:
```
t.index ["name"], :name => "usernamelower", :case_sensitive => false, :operator_class => {nil => "text_pattern_ops"}
```
which will not load properly.

This will now output the following schema line:
```
t.index ["name"], :name => "usernamelower", :case_sensitive => false, :operator_class => {'name' => "text_pattern_ops"}
```