### PR TITLE
Arjdbc greater 1.3.12 compatibility. Fix #214

### DIFF
--- a/schema_dev.yml
+++ b/schema_dev.yml
@@ -34,6 +34,3 @@ exclude:
   -
     ruby: jruby
     db: sqlite3
-  -
-    ruby: jruby
-    db: postgresql


### PR DESCRIPTION
Here is a fix for compatibility with > activerecord-jdbc-1.3.12. I hope this solution is normal, because I can't find more elegant way
