### PR TITLE
gemspec: Drop defunct property rubyforge_project

### DIFF
--- a/schema_plus.gemspec
+++ b/schema_plus.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |gem|
   gem.description = "SchemaPlus is a gem that simply pulls in a collection of other gems from the SchemaPlus family of ActiveRecord extensions"
   gem.license = 'MIT'
 
-  gem.rubyforge_project = "schema_plus"
-
   gem.files         = `git ls-files`.split("\n")
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436